### PR TITLE
Add optional extra data to generateOptions response data

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -195,10 +195,11 @@ export class WebAuthnStrategy<User> extends Strategy<
     return rp;
   }
 
-  async generateOptions(
+  async generateOptions<ExtraData>(
     request: Request,
     sessionStorage: SessionStorage<SessionData, SessionData>,
-    user: User | null
+    user: User | null,
+    extraData?: ExtraData
   ) {
     let session = await sessionStorage.getSession(
       request.headers.get("Cookie")
@@ -226,7 +227,8 @@ export class WebAuthnStrategy<User> extends Strategy<
 
     const crypto = await import("tiny-webcrypto");
 
-    const options: WebAuthnOptionsResponse = {
+    type ExtraKey = ExtraData extends undefined ? undefined : ExtraData;
+    const options: WebAuthnOptionsResponse & { extra: ExtraKey } = {
       usernameAvailable,
       rp,
       user: userDetails
@@ -240,6 +242,7 @@ export class WebAuthnStrategy<User> extends Strategy<
         type: "public-key",
         transports: transports as AuthenticatorTransportFuture[],
       })),
+      extra: extraData as ExtraKey
     };
 
     session.set("challenge", options.challenge);


### PR DESCRIPTION
Firstly, appreciate your commitment to this package 🖤

As i was integrating it into my auth flow - I felt like i wanted a bit more control over the data returned from `generateOptions`. At the very least, I'd like to add additional keys that can be returned to the route.

Seeing how `generateOptions` currently returns a `Response` - the least invasive way that i came up with was to add an optional fourth argument to the `generateOptions` method that will be included in the response data. 

Open for any other implementation ideas!