### PR TITLE
Make attestation type configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ export default function Login() {
 You can set the [`attestationType`](https://simplewebauthn.dev/docs/packages/server#1a-supported-attestation-formats) in the second parameter of `handleFormSubmit`. If omitted, it defaults to `none`:
 
 ```tsx
-handleFormSubmit(options, { attestationType: "direct" });
+onSubmit={handleFormSubmit(options, { attestationType: "direct" })}
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ export default function Login() {
 }
 ```
 
+You can set the [`attestationType`](https://simplewebauthn.dev/docs/packages/server#1a-supported-attestation-formats) in the second parameter of `handleFormSubmit`. If omitted, it defaults to `none`:
+
+```tsx
+handleFormSubmit(options, { attestationType: "direct" });
+```
+
 ## TODO
 
 - Implement [Conditional UI](https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI)

--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -31,6 +31,12 @@ export function handleFormSubmit(
   config?: {
     /** Generate an unique user ID when registering new users */
     generateUserId?: () => string;
+
+    /**
+     * Specify the preference regarding attestation conveyance during credential generation.
+     * @link https://www.w3.org/TR/webauthn-2/#enumdef-attestationconveyancepreference
+     */
+    attestationType?: AttestationConveyancePreference;
   }
 ) {
   return async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -102,7 +108,7 @@ export function handleFormSubmit(
                 },
               ],
               timeout: 90 * 1000,
-              attestation: "none",
+              attestation: config?.attestationType || "none",
               authenticatorSelection: {
                 residentKey: "discouraged",
                 requireResidentKey: false,


### PR DESCRIPTION
Closes #15.

This PR makes `attestationType` configurable when passing to `simplewebauthn`'s `startRegistration` function.

You can configure this in the second parameter `config` of the `handleFormSubmit`, for example:

```tsx
onSubmit={handleFormSubmit(options, { attestationType: "direct" })}
```

If `attestationType` is not provided, it will use the default value of `"none"`.