### PR TITLE
Set userVerification to preferred in registration options

### DIFF
--- a/src/browser.tsx
+++ b/src/browser.tsx
@@ -112,6 +112,7 @@ export function handleFormSubmit(
               authenticatorSelection: {
                 residentKey: "discouraged",
                 requireResidentKey: false,
+                userVerification: "preferred",
               },
               extensions: { credProps: true },
             })


### PR DESCRIPTION
- In the authentication flow, `userVerification` is set to `"preferred"` so that user verification is only attempted when possible (i.e. biometric authentication methods like TouchID are presented when available, but it is not required for successful authentication).
- However, on the registration flow `userVerification` is not specified. Because of this, `userVerification` is required as this is the default in SimpleWebAuthn's [`verifyRegistrationResponse`](https://github.com/MasterKale/SimpleWebAuthn/blob/a169def3c663cb671cdc6bc6e00a4993944a61ae/packages/server/src/registration/verifyRegistrationResponse.ts#L194). This presents an issue during the registration flow when using iCloud Keychain or Chrome's built in passkey manager when no user verification method is available (e.g. when a MacBook is in clamshell mode and therefore TouchID is not present/available). In this case, the follow error is returned from `authenticator.authenticate()`: `User verification required, but user could not be verified`.
- This PR addresses this by specifying `userVerification: "preferred"` on the registration flow as well so that the user verification behaviour is consistent in both flows. This follows the guidance from [`web.dev`](https://web.dev/articles/webauthn-user-verification) on how to specify the `userVerification` parameter.