### PR TITLE
Set requireUserVerification to false during registration and authentication flow

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -286,6 +286,7 @@ export class WebAuthnStrategy<User> extends Strategy<
           expectedChallenge,
           expectedOrigin: rp.origin,
           expectedRPID: rp.id,
+          requireUserVerification: false,
         });
 
         if (verification.verified && verification.registrationInfo) {
@@ -336,6 +337,7 @@ export class WebAuthnStrategy<User> extends Strategy<
               ","
             ) as AuthenticatorTransportFuture[],
           },
+          requireUserVerification: false,
         });
 
         if (!verification.verified)


### PR DESCRIPTION
Follow up of #18 to set `requireUserVerification: false` on the `verifyRegistrationResponse` and `verifyAuthenticationResponse` so that it actually uses the `userVerification` preference, as per: https://github.com/MasterKale/SimpleWebAuthn/blob/a169def3c663cb671cdc6bc6e00a4993944a61ae/packages/server/src/authentication/verifyAuthenticationResponse.ts#L210

This properly fixes the issue outlined in #18, where the following error is presented on registration or authentication if the user verification method is not available (i.e. Macbook is in clamshell mode and TouchID is not available): `"User verification required, but user could not be verified"`.