### PR TITLE
Add aaguid property to Authenticator type

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,46 @@ You can set the [`attestationType`](https://simplewebauthn.dev/docs/packages/ser
 onSubmit={handleFormSubmit(options, { attestationType: "direct" })}
 ```
 
+## Displaying passkeys to the user
+
+An important part of supporting passkeys in your app is allowing your users to manage their passkeys on a settings page or similar. Users should be able to see a list of their passkeys, delete passkeys from your database, and register new passkeys.
+
+You can use the `getUserAuthenticators` function on the strategy instance to get a list of passkeys associated with the user:
+
+```tsx
+// /app/routes/settings.tsx
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await authenticator.isAuthenticated(request);
+  if (!user) {
+    return redirect("/login");
+  }
+
+  const authenticators = await webAuthnStrategy.getUserAuthenticators(user);
+
+  return json({ authenticators });
+};
+
+export default function Settings() {
+  const data = useLoaderData();
+
+  return (
+    <ul>
+      {data.authenticators.map((authenticator) => (
+        ...
+      ))}
+    </ul>
+  );
+}
+```
+
+When listing passkeys, it's also helpful to display the name of the device that registered the passkey to the user so they can distinguish between them (especially when they have multiple passkeys registered). To accomplish this, you can use the community-sourced list available in the [passkey-authenticator-aaguids](https://github.com/passkeydeveloper/passkey-authenticator-aaguids) repository to match each authenticator's `aaguid` to its registering device and display the name (and even a brand icon) to the user.
+
+To learn more about best practices for passkey management, refer to Google's [Passkeys user journeys](https://developers.google.com/identity/passkeys/ux/user-journeys) guide.
+
 ## TODO
 
 - Implement [Conditional UI](https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI)
+
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ interface Authenticator {
   // SQL: `VARCHAR(255)` and store string array or a CSV string
   // Ex: ['usb' | 'ble' | 'nfc' | 'internal']
   transports: string;
+  // SQL: `VARCHAR(36)` or similar, since AAGUIDs are 36 characters in length
+  aaguid: string;
 }
 ```
 
@@ -243,7 +245,7 @@ export async function loader({ request, response }: LoaderFunctionArgs) {
 
   // Set the challenge in a session cookie so it can be accessed later.
   session.set("challenge", options.challenge)
-  
+
   // Update the cookie
   response.headers.append("Set-Cookie", await sessionStorage.commitSession(session))
   response.headers.set("Cache-Control":"no-store")
@@ -271,11 +273,11 @@ If you choose to store the challenge somewhere other than session storage, such 
 
 ```ts
 export async function action({ request }: ActionFunctionArgs) {
-  const challenge = await getChallenge(request)
+  const challenge = await getChallenge(request);
   try {
     await authenticator.authenticate("webauthn", request, {
       successRedirect: "/",
-      context: { challenge }
+      context: { challenge },
     });
     return { error: null };
   } catch (error) {

--- a/README.md
+++ b/README.md
@@ -389,7 +389,3 @@ To learn more about best practices for passkey management, refer to Google's [Pa
 ## TODO
 
 - Implement [Conditional UI](https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI)
-
-```
-
-```

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ export interface Authenticator {
   credentialDeviceType: string;
   credentialBackedUp: boolean;
   transports: string;
+  aaguid: string;
 }
 
 export interface UserDetails {
@@ -296,6 +297,7 @@ export class WebAuthnStrategy<User> extends Strategy<
             counter,
             credentialBackedUp,
             credentialDeviceType,
+            aaguid,
           } = verification.registrationInfo;
 
           const newAuthenticator = {
@@ -305,6 +307,7 @@ export class WebAuthnStrategy<User> extends Strategy<
             credentialBackedUp,
             credentialDeviceType,
             transports: "",
+            aaguid,
           };
 
           user = await this.verify({


### PR DESCRIPTION
As mentioned in #15, the `aaguid` from [`registrationInfo`](https://github.com/MasterKale/SimpleWebAuthn/blob/a169def3c663cb671cdc6bc6e00a4993944a61ae/packages/server/src/registration/verifyRegistrationResponse.ts#L284) is needed to determine the type of authenticator used to save the passkey. The name of the authenticator can be determined by comparing against [this file](https://github.com/passkeydeveloper/passkey-authenticator-aaguids/blob/main/aaguid.json) from the community sourced list of passkey authenticators.

This PR adds `aaguid` to the properties of the `Authenticator` type so implementing apps can access this information and display the passkey authenticator to the user, which is a big part of the "Managing passkeys" section of the [Passkey user journeys](https://developers.google.com/identity/passkeys/ux/user-journeys#make_it_easy_for_users_to_find_passkeys_within_your_service) article published by Google.